### PR TITLE
fix seqkit split --force to create output directory after removing existing one

### DIFF
--- a/seqkit/cmd/split.go
+++ b/seqkit/cmd/split.go
@@ -122,6 +122,7 @@ Examples:
 					if !empty {
 						if force {
 							checkError(os.RemoveAll(outdir))
+							checkError(os.MkdirAll(outdir, 0777))
 						} else {
 							log.Warningf("outdir not empty: %s, you can use --force to overwrite", outdir)
 						}

--- a/seqkit/cmd/split2.go
+++ b/seqkit/cmd/split2.go
@@ -169,6 +169,7 @@ according to the input files.
 					if !empty {
 						if force {
 							checkError(os.RemoveAll(outdir))
+							checkError(os.MkdirAll(outdir, 0777))
 						} else {
 							log.Warningf("outdir not empty: %s, you can use --force to overwrite", outdir)
 						}


### PR DESCRIPTION
Hi Wei,

I found `seqkit split --force` behaving somewhat unexpected way, the first run removes the existing output directory with no output and the second run places files as expected. It seems due to missing `os.MkdirAll` after removing existing directory when `force` flag is set.

(I'm sorry bothering you if the original behavior was intentional one.)

Thanks,

Hajime Suzuki