### PR TITLE
Specify `seq` command can reverse complement

### DIFF
--- a/seqkit/cmd/seq.go
+++ b/seqkit/cmd/seq.go
@@ -43,8 +43,8 @@ import (
 // seqCmd represents the seq command
 var seqCmd = &cobra.Command{
 	Use:   "seq",
-	Short: "transform sequences (extract ID, filter by length, remove gaps...)",
-	Long: `transform sequences (extract ID, filter by length, remove gaps...)
+	Short: "transform sequences (extract ID, filter by length, remove gaps, reverse complement...)",
+	Long: `transform sequences (extract ID, filter by length, remove gaps, reverse complement...)
 
 `,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Thanks for the tool!

I wanted to reverse complement a seq today and wasn't immediately obvious `seq` subcommand did that. I think it's a common enough thing to do to advertise in the help menu. That's all the PR proposes to add.