### PR TITLE
Use ASCIISet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
+	github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab // indirect
 	github.com/go-fonts/liberation v0.3.0 // indirect
 	github.com/go-latex/latex v0.0.0-20230307184459-12ec69307ad9 // indirect
 	github.com/go-pdf/fpdf v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab h1:h1UgjJdAAhj+uPL68n7XASS6bU+07ZX1WJvVS2eyoeY=
+github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=

--- a/seqkit/cmd/fx2tab.go
+++ b/seqkit/cmd/fx2tab.go
@@ -30,6 +30,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/elliotwutingfeng/asciiset"
 	"github.com/shenwei356/bio/seq"
 	"github.com/shenwei356/bio/seqio/fastx"
 	"github.com/shenwei356/xopen"
@@ -253,16 +254,14 @@ func init() {
 }
 
 func alphabetStr(s []byte) string {
-	m := make(map[byte]struct{})
-	for _, b := range s {
-		m[b] = struct{}{}
-	}
-	alphabet := make([]string, len(m))
+	m, _ := asciiset.MakeASCIISet(string(s))
+	alphabet := make([]string, m.Size())
 	i := 0
-	for a := range m {
+	m.Visit(func(a byte) bool {
 		alphabet[i] = string([]byte{a})
 		i++
-	}
+		return false
+	})
 	sort.Strings(alphabet)
 	return strings.Join(alphabet, "")
 }

--- a/seqkit/cmd/util.go
+++ b/seqkit/cmd/util.go
@@ -31,72 +31,16 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/elliotwutingfeng/asciiset"
 	au "github.com/logrusorgru/aurora"
 	colorable "github.com/mattn/go-colorable"
 	isatty "github.com/mattn/go-isatty"
 )
 
-var IUPACBases map[byte]bool
-var IUPACAminoAcids map[byte]bool
+var IUPACBases, _ = asciiset.MakeASCIISet("ACGTRYSWKMBDHVNUacgtryswkmbdhvnu")
+var IUPACAminoAcids, _ = asciiset.MakeASCIISet("ACDEFGHIKLMNPQRSTVWY")
 
 func init() {
-	IUPACBases = map[byte]bool{
-		'A': true,
-		'C': true,
-		'G': true,
-		'T': true,
-		'R': true,
-		'Y': true,
-		'S': true,
-		'W': true,
-		'K': true,
-		'M': true,
-		'B': true,
-		'D': true,
-		'H': true,
-		'V': true,
-		'N': true,
-		'U': true,
-		'a': true,
-		'c': true,
-		'g': true,
-		't': true,
-		'r': true,
-		'y': true,
-		's': true,
-		'w': true,
-		'k': true,
-		'm': true,
-		'b': true,
-		'd': true,
-		'h': true,
-		'v': true,
-		'n': true,
-		'u': true,
-	}
-
-	IUPACAminoAcids = map[byte]bool{
-		'A': true,
-		'C': true,
-		'D': true,
-		'E': true,
-		'F': true,
-		'G': true,
-		'H': true,
-		'I': true,
-		'K': true,
-		'L': true,
-		'M': true,
-		'N': true,
-		'P': true,
-		'Q': true,
-		'R': true,
-		'S': true,
-		'T': true,
-		'V': true,
-		'W': true,
-		'Y': true,
-	}
 }
 
 // ColorCycler is a utilty object to cycle between colors and colorize text.
@@ -206,7 +150,7 @@ func NewSeqColorizer(alphabet string) *SeqColorizer {
 	}
 	res.Alphabet = alphabet
 	i := auStart
-	for base, _ := range IUPACBases {
+	IUPACBases.Visit(func(base byte) bool {
 		switch base {
 		case 'A', 'a':
 			res.NucPalette[base] = au.GreenFg
@@ -224,10 +168,11 @@ func NewSeqColorizer(alphabet string) *SeqColorizer {
 			res.NucPalette[base] = i<<auShiftFg | auFlagFg
 			i += auSkip
 		}
-	}
+		return false
+	})
 
 	// The Lesk color scheme from http://www.bioinformatics.nl/~berndb/aacolour.html
-	for aa, _ := range IUPACAminoAcids {
+	IUPACAminoAcids.Visit(func(aa byte) bool {
 		switch aa {
 		case 'G', 'A', 'S', 'T': // Small nonpolar
 			res.ProtPalette[aa] = au.YellowFg
@@ -244,8 +189,8 @@ func NewSeqColorizer(alphabet string) *SeqColorizer {
 		case '-', '*': // Gap
 			res.ProtPalette[aa] = au.WhiteFg
 		}
-
-	}
+		return false
+	})
 
 	gb := uint8(239)
 	for i := 33; i < 90; i++ {


### PR DESCRIPTION
Proposing use of `ASCIISet` instead of `map[byte]struct{}` or `map[byte]bool`.

`ASCIISet` is a zero-dependency library for sets of ASCII characters with [28 times faster lookup speed](https://github.com/elliotwutingfeng/asciiset#results) than `map[byte]struct{}` or `map[byte]bool`.