### PR TITLE
Update nucleotide colors to use Red/Yellow for C/G

### DIFF
--- a/seqkit/cmd/util.go
+++ b/seqkit/cmd/util.go
@@ -155,13 +155,13 @@ func NewSeqColorizer(alphabet string) *SeqColorizer {
 		case 'A', 'a':
 			res.NucPalette[base] = au.GreenFg
 		case 'C', 'c':
-			res.NucPalette[base] = au.BlueFg
+			res.NucPalette[base] = au.RedFg
 		case 'G', 'g':
 			res.NucPalette[base] = au.YellowFg
 		case 'T', 't':
-			res.NucPalette[base] = au.RedFg
+			res.NucPalette[base] = au.BlueFg
 		case 'U', 'u':
-			res.NucPalette[base] = au.RedFg
+			res.NucPalette[base] = au.BlueFg
 		case '-', '*':
 			res.NucPalette[base] = au.WhiteFg
 		default:


### PR DESCRIPTION
Hi, thanks for this fabulous tool - I use it all the time!

The proposed change is admittedly a matter of taste, so take it with a grain of salt, but I noticed from my personal experimentation with coloring that keeping G & C in the Red/Yellow part of the color scale, makes it possible to somewhat spot differences in GC-content at a glance, which might be useful sometimes.

Fully understand if there are other considerations at play here, but just a suggestion :)