### PR TITLE
doc: Fix docstring for tail, add necessary `--range`

### DIFF
--- a/doc/docs/usage.md
+++ b/doc/docs/usage.md
@@ -2902,7 +2902,7 @@ Usage
 print first N FASTA/Q records
 
 For returning the last N records, use:
-    seqkit range -N:-1 seqs.fasta
+    seqkit range -r -N:-1 seqs.fasta
 
 Usage:
   seqkit head [flags]

--- a/seqkit/cmd/head.go
+++ b/seqkit/cmd/head.go
@@ -37,7 +37,7 @@ var headCmd = &cobra.Command{
 	Long: `print first N FASTA/Q records
 
 For returning the last N records, use:
-    seqkit range --range -N:-1 seqs.fasta
+    seqkit range -r -N:-1 seqs.fasta
 
 `,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/seqkit/cmd/head.go
+++ b/seqkit/cmd/head.go
@@ -37,7 +37,7 @@ var headCmd = &cobra.Command{
 	Long: `print first N FASTA/Q records
 
 For returning the last N records, use:
-    seqkit range -N:-1 seqs.fasta
+    seqkit range --range -N:-1 seqs.fasta
 
 `,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Docstring for `seqkit head` says: `For returning the last N records, use: seqkit range -N:-1 seqs.fasta` This is incorrect, as the range argument is not positional and requires a flag `-r/--range` This PR fixes that.