### PR TITLE
Add documentation for paired-end sequence sampling

### DIFF
--- a/seqkit/cmd/sample.go
+++ b/seqkit/cmd/sample.go
@@ -204,7 +204,7 @@ Attention:
 func init() {
 	RootCmd.AddCommand(sampleCmd)
 
-	sampleCmd.Flags().Int64P("rand-seed", "s", 11, "rand seed")
+	sampleCmd.Flags().Int64P("rand-seed", "s", 11, "random seed. For paired-end data, use the same seed across fastq files to sample the same read pairs")
 	sampleCmd.Flags().Int64P("number", "n", 0, "sample by number (result may not exactly match), DO NOT use on large FASTQ files.")
 	sampleCmd.Flags().Float64P("proportion", "p", 0, "sample by proportion")
 	sampleCmd.Flags().BoolP("two-pass", "2", false, "2-pass mode read files twice to lower memory usage. Not allowed when reading from stdin")


### PR DESCRIPTION
Hello!
I propose adding a sentence to document how to `sample` read pairs in a coordinated fashion - namely, by using the same seed `-s` value across FASTQs

This is what happens by default (as the seed is fixed to a given value by default), but I would say it's a good idea to state that fixing the seed achieves this

Best,
Brice