### PR TITLE
Code clean up around error checking for translate command

### DIFF
--- a/seqkit/cmd/translate.go
+++ b/seqkit/cmd/translate.go
@@ -194,17 +194,13 @@ Translate Tables/Genetic Codes:
 
 				for _, frame = range frames {
 					_seq, err = record.Seq.Translate(translTable, frame, trim, clean, allowUnknownCodon, markInitCodonAsM)
-
-					if err != nil {
-						if skipTranslateErrors {
-							outfh.WriteString(fmt.Sprintf(">%s %s\n\n", record.ID, record.Desc))
-							continue
-						}
-						if err == seq.ErrUnknownCodon {
-							log.Error("unknown codon detected, you can use flag -x/--allow-unknown-codon to translate it to 'X'.")
-							os.Exit(-1)
-						}
-						checkError(err)
+					if err != nil && skipTranslateErrors {
+						outfh.WriteString(fmt.Sprintf(">%s %s\n\n", record.ID, record.Desc))
+						continue
+					}
+					if err != nil && err == seq.ErrUnknownCodon {
+						log.Error("unknown codon detected, you can use flag -x/--allow-unknown-codon to translate it to 'X'.")
+						os.Exit(-1)
 					}
 					checkError(err)
 


### PR DESCRIPTION
Just cleaning up some error checking here code here after adding the `skipTranslateErrors` flag.
checkError already has the if err != nil check and was redundant the way it was written.

I verified this worked by building and testing against my dataset. 