### PR TITLE
Fix standalone usage of `{fbne}` in `seqkit replace`

### DIFF
--- a/seqkit/cmd/replace.go
+++ b/seqkit/cmd/replace.go
@@ -147,7 +147,7 @@ Filtering records to edit:
 		}
 
 		var replaceWithFBNE bool
-		if reFN.Match(replacement) {
+		if reFBNE.Match(replacement) {
 			replaceWithFBNE = true
 		}
 


### PR DESCRIPTION
This PR will fix the standalone usage of `{fbne}` in `seqkit replace`.

`seqkit replace ../tests/hairpin.fa -p '.+' -r '{fbne}' | seqkit seq -n | head -n 3` will now give the correct output:
```
hairpin
hairpin
hairpin
```
rather than
```
{fbne}
{fbne}
{fbne}
```