### PR TITLE
Add early exit for `grep --delete-matched` when no patterns remain

### DIFF
--- a/seqkit/cmd/grep.go
+++ b/seqkit/cmd/grep.go
@@ -551,6 +551,10 @@ Examples:
 
 			checkAlphabet := true
 			for {
+				if len(patternsR)+len(patternsN)+len(patternsS) == 0 {
+					break
+				}
+
 				record, err = fastxReader.Read()
 				if err != nil {
 					if err == io.EOF {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -264,6 +264,10 @@ run grep_by_regexp_list $app grep -r -n -f list $file
 assert_equal $($app fx2tab $STDOUT_FILE | wc -l) $($app seq -n $file | grep -E "Homo|Mus" | wc -l)
 rm list
 
+# delete matched
+run grep_delete_matched $app grep --delete-matched -r -p "^hsa" $file
+assert_equal $(cat $STDOUT_FILE | md5sum | cut -d" " -f 1) $($app fx2tab $file | grep -E "^hsa" | head -n 1 | $app tab2fx | md5sum | cut -d" " -f 1)
+
 # ------------------------------------------------------------
 #                       locate
 # ------------------------------------------------------------


### PR DESCRIPTION
This PR adds an early exit to `grep` when there aren't any patterns left to search for, such as when using `--delete-matched` and all patterns have already been matched. In this case, we know we will never print anything else after all patterns have been matched, so we don't need to read any more of the file (which could take quite a long time depending on how large the file is and how far we have already read).

I also added a simple test for `grep --delete-matched` to help check the basic functionality, which asserts that only the first match for a pattern is returned. I couldn't think of a good way to also check that the grep exits early and the rest of the file isn't read though, but I figured this test at least helps ensure that I didn't break anything with this change.