### PR TITLE
doc(grep): clarify help text on how to pass multiple patterns

### DIFF
--- a/doc/docs/usage.md
+++ b/doc/docs/usage.md
@@ -1727,8 +1727,9 @@ Flags:
   -m, --max-mismatch int            max mismatch when matching by seq. For large genomes like human
                                     genome, using mapping/alignment tools would be faster
   -P, --only-positive-strand        only search on the positive strand
-  -p, --pattern strings             search pattern (multiple values supported. Attention: use double
-                                    quotation marks for patterns containing comma, e.g., -p '"A{2,}"')
+  -p, --pattern strings             search pattern. Multiple patterns supported: comma-separated
+                                    (e.g., -p "p1,p2") OR use -p multiple times (e.g., -p p1 -p p2).
+                                    Make sure to quote literal commas, e.g. in regex patterns '"A{2,}"'
   -f, --pattern-file string         pattern file (one record per line)
   -R, --region string               specify sequence region for searching. e.g 1:12 for first 12 bases,
                                     -12:-1 for last 12 bases

--- a/seqkit/cmd/grep.go
+++ b/seqkit/cmd/grep.go
@@ -727,7 +727,9 @@ Examples:
 func init() {
 	RootCmd.AddCommand(grepCmd)
 
-	grepCmd.Flags().StringSliceP("pattern", "p", []string{""}, `search pattern (multiple values supported. Attention: use double quotation marks for patterns containing comma, e.g., -p '"A{2,}"')`)
+	grepCmd.Flags().StringSliceP("pattern", "p", []string{""}, `search pattern. Multiple patterns supported: comma-separated 
+(e.g., -p "p1,p2") OR use -p multiple times (e.g., -p p1 -p p2).
+Make sure to quote literal commas, e.g. in regex patterns '"A{2,}"'`)
 	grepCmd.Flags().BoolP("allow-duplicated-patterns", "D", false, "output records multiple times when duplicated patterns are given")
 	grepCmd.Flags().StringP("pattern-file", "f", "", "pattern file (one record per line)")
 	grepCmd.Flags().BoolP("use-regexp", "r", false, "patterns are regular expression")


### PR DESCRIPTION
It took me a minute or so to figure out how to pass multiple patterns.

This PR provides explicit examples on the syntax to pass multiple strings.

The (almost) same text also appears in the `locate`, `mutate`, `replace` subcommands. These could be changed as well - either in this or a future PR (and the help text potentially put in a single place to keep things DRY).